### PR TITLE
fix: [LM2-349] update uat environment name

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -78,7 +78,6 @@ class Client
     /**
      * Set a defined handler.
      *
-     * @return array
      */
     protected function setHandler($key, $value)
     {

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -19,7 +19,7 @@ class Environment
 
     const STAGING = "staging";
 
-    const USER_ACCEPTANCE_TESTING = "user-acceptance-testing";
+    const USER_ACCEPTANCE_TESTING = "uat";
 
     const PRODUCTION = "production";
 

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -19,6 +19,8 @@ class Environment
 
     const STAGING = "staging";
 
+    const USER_ACCEPTANCE_TESTING = "user-acceptance-testing";
+
     const PRODUCTION = "production";
 
     const LIVE = "production";
@@ -40,4 +42,21 @@ class Environment
             'base_uri' => 'https://merchant.api.divido.com',
         ],
     ];
+
+    /**
+     * Get the environment based off of the provided API key
+     *
+     *
+     * @param string $apiKey The API key to get the environment from
+     *
+     * @return string The environment corresponding to the API key
+     */
+    public function getEnvironmentFromAPIKey($apiKey)
+    {
+        $splitApiKey = explode('_', $apiKey);
+        $environment = str_replace('-','_',strtoupper($splitApiKey[0]));
+        return ('LIVE' == $environment)
+            ? constant('self::PRODUCTION')
+            : constant('self::'. $environment);
+    }
 }

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -51,7 +51,7 @@ class Environment
      *
      * @return string The environment corresponding to the API key
      */
-    public function getEnvironmentFromAPIKey($apiKey)
+    public static function getEnvironmentFromAPIKey($apiKey)
     {
         $splitApiKey = explode('_', $apiKey);
         $environment = str_replace('-','_',strtoupper($splitApiKey[0]));

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -55,7 +55,8 @@ class Environment
     {
         $splitApiKey = explode('_', $apiKey);
         $environment = str_replace('-','_',strtoupper($splitApiKey[0]));
-        return ('LIVE' == $environment)
+
+        return ('LIVE' === $environment)
             ? constant('self::PRODUCTION')
             : constant('self::'. $environment);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "divido-merchant-sdk",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "scripts": {
     "release": "standard-version"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "divido-merchant-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "scripts": {
     "release": "standard-version"
   },

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -9,42 +9,24 @@ class EnvironmentTest extends MerchantSDKTestCase
     /**
      * Test getting the correct environment based on the api key
      *
+     * @dataProvider provider_test_GettingEnvironment_WithSuppliedAPIKey_ReturnsCorrectEnvironment
      */
-    public function test_GettingEnvironment_WithSuppliedAPIKey_ReturnsCorrectEnvironment()
+    public function test_GettingEnvironment_WithSuppliedAPIKey_ReturnsCorrectEnvironment($suppliedArgument, $expectedResponse)
     {
-        // Dev api keys should be correctly identified
-        $apiKey = 'dev_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("dev", $result);
+        $result = Environment::getEnvironmentFromAPIKey($suppliedArgument);
+        $this->assertSame($expectedResponse, $result);
+    }
 
-        // Testing api keys should be correctly identified
-        $apiKey = 'testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("testing", $result);
-
-        // Staging api keys should be correctly identified
-        $apiKey = 'staging_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("staging", $result);
-
-        // Sandbox api keys should be correctly identified
-        $apiKey = 'sandbox_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("sandbox", $result);
-
-        // UAT api keys should be correctly identified
-        $apiKey = 'user-acceptance-testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("user-acceptance-testing", $result);
-
-        // Production api keys should be correctly identified
-        $apiKey = 'production_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("production", $result);
-
-        // Live api keys should be correctly identified
-        $apiKey = 'live_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
-        $result = Environment::getEnvironmentFromAPIKey($apiKey);
-        $this->assertSame("production", $result);
+    public function provider_test_GettingEnvironment_WithSuppliedAPIKey_ReturnsCorrectEnvironment()
+    {
+        return [
+            ["dev_f9425ece.3ec313437567c831d289efbdc240dd75'", "dev"],
+            ["testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "testing"],
+            ["staging_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "staging"],
+            ["sandbox_f9425ece.3ec313437567c831d289efbdc240dd75", "sandbox"],
+            ["user-acceptance-testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "user-acceptance-testing"],
+            ["production_f9425ece.3ec313437567c831d289efbdc240dd75", "production"],
+            ["live_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "production"]
+        ];
     }
 }

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -24,7 +24,7 @@ class EnvironmentTest extends MerchantSDKTestCase
             ["testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "testing"],
             ["staging_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "staging"],
             ["sandbox_f9425ece.3ec313437567c831d289efbdc240dd75", "sandbox"],
-            ["user-acceptance-testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "user-acceptance-testing"],
+            ["user-acceptance-testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "uat"],
             ["production_f9425ece.3ec313437567c831d289efbdc240dd75", "production"],
             ["live_pk_f9425ece.3ec313437567c831d289efbdc240dd75", "production"]
         ];

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Divido\MerchantSDK\Test\unit;
+
+use Divido\MerchantSDK\Environment;
+
+class EnvironmentTest extends MerchantSDKTestCase
+{
+    /**
+     * Test getting the correct environment based on the api key
+     *
+     */
+    public function test_GettingEnvironment_WithSuppliedAPIKey_ReturnsCorrectEnvironment()
+    {
+        // Dev api keys should be correctly identified
+        $apiKey = 'dev_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("dev", $result);
+
+        // Testing api keys should be correctly identified
+        $apiKey = 'testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("testing", $result);
+
+        // Staging api keys should be correctly identified
+        $apiKey = 'staging_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("staging", $result);
+
+        // Sandbox api keys should be correctly identified
+        $apiKey = 'sandbox_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("sandbox", $result);
+
+        // UAT api keys should be correctly identified
+        $apiKey = 'user-acceptance-testing_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("user-acceptance-testing", $result);
+
+        // Production api keys should be correctly identified
+        $apiKey = 'production_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("production", $result);
+
+        // Live api keys should be correctly identified
+        $apiKey = 'live_pk_f9425ece.3ec313437567c831d289efbdc240dd75';
+        $result = Environment::getEnvironmentFromAPIKey($apiKey);
+        $this->assertSame("production", $result);
+    }
+}

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Divido\MerchantSDK\Test\unit;
+namespace Divido\MerchantSDK\Test\Unit;
 
 use Divido\MerchantSDK\Environment;
 


### PR DESCRIPTION
This fix is needed so that, in the plugins, the correct environment name will be used to automatically generate the url that points to the calculator widget for that environment.

For example, https://cdn.divido.com/widget/v3/ing.user-acceptance-testing.calculator.js?ver=1 should be https://cdn.divido.com/widget/v3/ing.uat.calculator.js?ver=1.