### PR TITLE
fix: null applicants/order items

### DIFF
--- a/lib/Models/Application.php
+++ b/lib/Models/Application.php
@@ -42,12 +42,12 @@ class Application extends AbstractModel
     protected $languageId;
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $applicants = [];
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $orderItems = [];
 
@@ -192,11 +192,11 @@ class Application extends AbstractModel
     /**
      * With applicants.
      *
-     * @param array $applicants
+     * @param array|null $applicants
      *
      * @return \Divido\MerchantSDK\Models\Application
      */
-    public function withApplicants(array $applicants)
+    public function withApplicants(?array $applicants)
     {
         $cloned = clone $this;
 
@@ -208,11 +208,11 @@ class Application extends AbstractModel
     /**
      * With order items.
      *
-     * @param array $orderItems
+     * @param array|null $orderItems
      *
      * @return \Divido\MerchantSDK\Models\Application
      */
-    public function withOrderItems(array $orderItems)
+    public function withOrderItems(?array $orderItems)
     {
         $cloned = clone $this;
 


### PR DESCRIPTION
Applicants are currently automatically generated with an empty array for their `applicants` and `order_items` fields. This is not really a problem except for when patching an application, as - thankfully - the merchant API Pub requires at least one item in the arrays, and thus returns a 400 (rather than just scrubbing the applicant/order information). So to get around this, one must retrieve the applicant/order information from the application and replicate it for the patch payload, so as not to change either of the fields. 

This PR allows us to overwrite the array fields if required, to null so that these fields can be ignored when [generating the json](https://github.com/dividohq/merchant-api-pub-sdk-php/blob/5e8f9ff7ef6b47d74225bed6fd5f4992ec438b89/lib/Models/AbstractModel.php#L34) for [the request](https://github.com/dividohq/merchant-api-pub-sdk-php/blob/5e8f9ff7ef6b47d74225bed6fd5f4992ec438b89/lib/Handlers/Applications/Handler.php#L147) to the Merchant API Pub.

Ideally we'd be defaulting these fields as null from the off to make things more explicit, but as it has existed in the code for so long like this, it's hard to say whether any integrations will be broken by enforcing such a change, whereas, as this requires the integration to explicitly set the field to null, it should have no backwards compatibility issues