### PR TITLE
fix: LM2-1503 uppercase http methods

### DIFF
--- a/lib/Handlers/AbstractHttpHandler.php
+++ b/lib/Handlers/AbstractHttpHandler.php
@@ -18,6 +18,13 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class AbstractHttpHandler
 {
+    const POST_METHOD = 'POST';
+    const GET_METHOD = 'GET';
+    const PUT_METHOD = 'PUT';
+    const PATCH_METHOD = 'PATCH';
+    const DELETE_METHOD = 'DELETE';
+    const HEAD_METHOD = 'HEAD';
+
     /**
      * @var WrapperInterface
      */

--- a/lib/Handlers/ApplicationActivations/Handler.php
+++ b/lib/Handlers/ApplicationActivations/Handler.php
@@ -93,7 +93,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;
@@ -127,7 +127,7 @@ class Handler extends AbstractHttpHandler
             $activationId,
         ]);
 
-        return $this->wrapper->request('get', $path);
+        return $this->wrapper->request(self::GET_METHOD, $path);
     }
 
     /**
@@ -145,6 +145,6 @@ class Handler extends AbstractHttpHandler
             'activations',
         ]);
 
-        return $this->wrapper->request('post', $path, [], [], $applicationActivation->getJsonPayload());
+        return $this->wrapper->request(self::POST_METHOD, $path, [], [], $applicationActivation->getJsonPayload());
     }
 }

--- a/lib/Handlers/ApplicationCancellations/Handler.php
+++ b/lib/Handlers/ApplicationCancellations/Handler.php
@@ -93,7 +93,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;
@@ -127,7 +127,7 @@ class Handler extends AbstractHttpHandler
             $cancellationId,
         ]);
 
-        return $this->wrapper->request('get', $path);
+        return $this->wrapper->request(self::GET_METHOD, $path);
     }
 
     /**
@@ -145,6 +145,6 @@ class Handler extends AbstractHttpHandler
             'cancellations',
         ]);
 
-        return $this->wrapper->request('post', $path, [], [], $applicationCancellation->getJsonPayload());
+        return $this->wrapper->request(self::POST_METHOD, $path, [], [], $applicationCancellation->getJsonPayload());
     }
 }

--- a/lib/Handlers/ApplicationDocuments/Handler.php
+++ b/lib/Handlers/ApplicationDocuments/Handler.php
@@ -33,7 +33,7 @@ class Handler extends AbstractHttpHandler
             'documents',
         ]);
 
-        return $this->wrapper->request('post', $path, [], ['Content-Type' => 'multipart/form-data'], $applicationDocument->getJsonPayload());
+        return $this->wrapper->request(self::POST_METHOD, $path, [], ['Content-Type' => 'multipart/form-data'], $applicationDocument->getJsonPayload());
     }
 
     /**
@@ -52,6 +52,6 @@ class Handler extends AbstractHttpHandler
             $applicationDocumentId,
         ]);
 
-        return $this->wrapper->request('delete', $path);
+        return $this->wrapper->request(self::DELETE_METHOD, $path);
     }
 }

--- a/lib/Handlers/ApplicationRefunds/Handler.php
+++ b/lib/Handlers/ApplicationRefunds/Handler.php
@@ -93,7 +93,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;
@@ -127,7 +127,7 @@ class Handler extends AbstractHttpHandler
             $refundId,
         ]);
 
-        return $this->wrapper->request('get', $path);
+        return $this->wrapper->request(self::GET_METHOD, $path);
     }
 
     /**
@@ -145,6 +145,6 @@ class Handler extends AbstractHttpHandler
             'refunds',
         ]);
 
-        return $this->wrapper->request('post', $path, [], [], $applicationRefund->getJsonPayload());
+        return $this->wrapper->request(self::POST_METHOD, $path, [], [], $applicationRefund->getJsonPayload());
     }
 }

--- a/lib/Handlers/Applications/Handler.php
+++ b/lib/Handlers/Applications/Handler.php
@@ -87,7 +87,7 @@ class Handler extends AbstractHttpHandler
             'filter' => $options->getFilters(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;
@@ -117,7 +117,7 @@ class Handler extends AbstractHttpHandler
             $applicationId,
         ]);
 
-        return $this->wrapper->request('get', $path);
+        return $this->wrapper->request(self::GET_METHOD, $path);
     }
 
     /**
@@ -132,7 +132,7 @@ class Handler extends AbstractHttpHandler
             'applications',
         ]);
 
-        return $this->wrapper->request('post', $path, $query, $headers, $application->getJsonPayload());
+        return $this->wrapper->request(self::POST_METHOD, $path, $query, $headers, $application->getJsonPayload());
     }
 
     /**
@@ -148,6 +148,6 @@ class Handler extends AbstractHttpHandler
             $application->getId(),
         ]);
 
-        return $this->wrapper->request('patch', $path, [], [], $application->getJsonPayload());
+        return $this->wrapper->request(self::PATCH_METHOD, $path, [], [], $application->getJsonPayload());
     }
 }

--- a/lib/Handlers/Channels/Handler.php
+++ b/lib/Handlers/Channels/Handler.php
@@ -84,7 +84,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;

--- a/lib/Handlers/Finances/Handler.php
+++ b/lib/Handlers/Finances/Handler.php
@@ -84,7 +84,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;

--- a/lib/Handlers/Health/Handler.php
+++ b/lib/Handlers/Health/Handler.php
@@ -20,7 +20,7 @@ class Handler extends AbstractHttpHandler
 
         // Make the request, catch exceptions 
         try {
-            $response = $this->wrapper->request('head', $path);
+            $response = $this->wrapper->request(self::HEAD_METHOD, $path);
             $status_code = $response->getStatusCode();
 
             $healthcheck["status_code"] = $status_code;

--- a/lib/Handlers/PlatformEnvironments/Handler.php
+++ b/lib/Handlers/PlatformEnvironments/Handler.php
@@ -23,6 +23,6 @@ class Handler extends AbstractHttpHandler
      */
     public function getPlatformEnvironment()
     {
-        return $this->wrapper->request('get', '/environment');
+        return $this->wrapper->request(self::GET_METHOD, '/environment');
     }
 }

--- a/lib/Handlers/Settlements/Handler.php
+++ b/lib/Handlers/Settlements/Handler.php
@@ -85,7 +85,7 @@ class Handler extends AbstractHttpHandler
             'sort' => $options->getSort(),
         ];
 
-        $response = $this->wrapper->request('get', $path, $query);
+        $response = $this->wrapper->request(self::GET_METHOD, $path, $query);
         $parsed = $this->parseResponse($response);
 
         return $parsed;
@@ -114,6 +114,6 @@ class Handler extends AbstractHttpHandler
             $settlementId,
         ]);
 
-        return $this->wrapper->request('get', $path);
+        return $this->wrapper->request(self::GET_METHOD, $path);
     }
 }

--- a/lib/Wrappers/HttpWrapper.php
+++ b/lib/Wrappers/HttpWrapper.php
@@ -72,7 +72,12 @@ class HttpWrapper implements WrapperInterface
 
         $uri = $this->baseUrl  . '/' . $uri . '?' . http_build_query($query, '', '&');
 
-        $request = $this->requestFactory->createRequest($method, $uri, $headers, $body);
+        $request = $this->requestFactory->createRequest(
+            strtoupper($method), 
+            $uri, 
+            $headers, 
+            $body
+        );
 
         try {
             $response = $this->httpClient->sendRequest($request);

--- a/tests/unit/Handlers/ApplicationActivationsHandlerTest.php
+++ b/tests/unit/Handlers/ApplicationActivationsHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Divido\MerchantSDK\Test\Unit;
 
+use Divido\MerchantSDK\Handlers\AbstractHttpHandler;
 use Divido\MerchantSDK\Handlers\ApiRequestOptions;
 use Divido\MerchantSDK\Handlers\ApplicationActivations\Handler;
 use Divido\MerchantSDK\Models\Application;
@@ -33,7 +34,7 @@ class ApplicationActivationsHandlerTest extends MerchantSDKTestCase
             '?page=1&sort=-created_at';
         $requestFactory = self::createMock(RequestFactory::class);
         $requestFactory->method('createRequest')
-            ->with('get', $expectedUri, ['X-Divido-Api-Key' => 'divido'], null)
+            ->with(AbstractHttpHandler::GET_METHOD, $expectedUri, ['X-Divido-Api-Key' => 'divido'], null)
             ->willReturn(self::createMock(RequestInterface::class));
 
         $wrapper = new HttpWrapper('-merchant-api-pub-http-host-', 'divido', $httpClient, $requestFactory);


### PR DESCRIPTION
A merchant has recorded issues when using the sdk (via Magento 2) using the Symfony client; reporting the following error:

> Next Symfony\Component\HttpClient\Psr18RequestException: Invalid HTTP method "get", only uppercase letters are accepted. in vendor/symfony/http-client/Psr18Client.php:122
Stack trace:
#0 vendor/divido/merchant-sdk/lib/Wrappers/HttpWrapper.php(73): Symfony\Component\HttpClient\Psr18Client->sendRequest()
#1 vendor/divido/merchant-sdk/lib/Handlers/Finances/Handler.php(85): Divido\MerchantSDK\Wrappers\HttpWrapper->request()
#2 [internal function]: Divido\MerchantSDK\Handlers\Finances\Handler->getPlansByPage()

This fix looks to ensure all methods are always presented in uppercase