### PR TITLE
fix: remove extra erroneous slash

### DIFF
--- a/lib/Handlers/PlatformEnvironments/Handler.php
+++ b/lib/Handlers/PlatformEnvironments/Handler.php
@@ -23,6 +23,6 @@ class Handler extends AbstractHttpHandler
      */
     public function getPlatformEnvironment()
     {
-        return $this->wrapper->request(self::GET_METHOD, '/environment');
+        return $this->wrapper->request(self::GET_METHOD, 'environment');
     }
 }


### PR DESCRIPTION
I have lost a day trying to figure out why my Shopify tests were failing 😭 

The path is already prepended with a slash [here](https://github.com/dividohq/merchant-api-pub-sdk-php/blob/515ef6035826fefc93fdb34465685a8aaf2abf49/lib/Wrappers/HttpWrapper.php#L73C19-L73C19)