### PR TITLE
chore: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PHP 5.6 and later.
 
 This SDK can be installed via [Composer](https://getcomposer.org/) using the following command:
 
-`composer require divido/merchant-api` 
+`composer require divido/merchant-sdk` 
 
 ## Basic SDK usage
 


### PR DESCRIPTION
Impressive how this has slipped under the radar for so long. [The package](https://packagist.org/packages/divido/merchant-sdk) is `-sdk` rather than `-api`